### PR TITLE
Feature/add touch validation

### DIFF
--- a/example/examples/OnTouchValidation.tsx
+++ b/example/examples/OnTouchValidation.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { DEBUG_FormWrapper } from "../DEBUG_FormWrapper";
+import { Field, useFormio } from "../../dist";
+
+const minLength10 = (value: string) =>
+  value.length < 10 ? "value has to have length >= 10" : undefined;
+
+export const OnTouchValidation = () => {
+  const form = useFormio(
+    {
+      firstName: "",
+      lastName: ""
+    },
+    {
+      firstName: { validator: minLength10 },
+      lastName: { validator: minLength10 }
+    }
+  );
+  const f = form.fields;
+
+  return (
+    <DEBUG_FormWrapper form={form}>
+      <form
+        onSubmit={async e => {
+          e.preventDefault();
+          const [isValid] = await form.validate();
+          if (isValid) alert("form is valid");
+        }}
+      >
+        <TextInput label={"First name"} {...f.firstName} />
+        <TextInput label={"Last name"} {...f.lastName} />
+        <button type="submit">Submit</button>
+      </form>
+    </DEBUG_FormWrapper>
+  );
+};
+
+const TextInput = React.memo((props: { label: string } & Field<string>) => {
+  return (
+    <div>
+      <label>{props.label}</label>
+      <input
+        type="text"
+        value={props.value}
+        onChange={e => {
+          props.set(e.target.value);
+          if (props.wasValidated) props.validate();
+        }}
+      />
+      <div className="input-error">{props.errors.join(", ")}</div>
+    </div>
+  );
+});

--- a/example/examples/OnTouchValidation.tsx
+++ b/example/examples/OnTouchValidation.tsx
@@ -35,7 +35,20 @@ export const OnTouchValidation = () => {
   );
 };
 
+// TODO:
+// - should I move this hook into the core use-formio library?
+// - add tests
+const useWasFieldValidated = <T,>(field: { isValidating: boolean }) => {
+  const [wasValidated, setWasValidated] = React.useState(false);
+  React.useEffect(() => {
+    if (field.isValidating === true) setWasValidated(true);
+  }, [field.isValidating]);
+
+  return wasValidated;
+};
+
 const TextInput = React.memo((props: { label: string } & Field<string>) => {
+  const wasFieldValidated = useWasFieldValidated(props);
   return (
     <div>
       <label>{props.label}</label>
@@ -44,7 +57,7 @@ const TextInput = React.memo((props: { label: string } & Field<string>) => {
         value={props.value}
         onChange={e => {
           props.set(e.target.value);
-          if (props.wasValidated) props.validate();
+          if (wasFieldValidated) props.validate();
         }}
       />
       <div className="input-error">{props.errors.join(", ")}</div>

--- a/example/examples/OnTouchValidation.tsx
+++ b/example/examples/OnTouchValidation.tsx
@@ -2,6 +2,15 @@ import * as React from "react";
 import { DEBUG_FormWrapper } from "../DEBUG_FormWrapper";
 import { Field, useFormio } from "../../dist";
 
+const useWasFieldValidated = <T,>(field: { isValidating: boolean }) => {
+  const [wasValidated, setWasValidated] = React.useState(false);
+  React.useEffect(() => {
+    if (field.isValidating === true) setWasValidated(true);
+  }, [field.isValidating]);
+
+  return wasValidated;
+};
+
 const minLength10 = (value: string) =>
   value.length < 10 ? "value has to have length >= 10" : undefined;
 
@@ -33,18 +42,6 @@ export const OnTouchValidation = () => {
       </form>
     </DEBUG_FormWrapper>
   );
-};
-
-// TODO:
-// - should I move this hook into the core use-formio library?
-// - add tests
-const useWasFieldValidated = <T,>(field: { isValidating: boolean }) => {
-  const [wasValidated, setWasValidated] = React.useState(false);
-  React.useEffect(() => {
-    if (field.isValidating === true) setWasValidated(true);
-  }, [field.isValidating]);
-
-  return wasValidated;
 };
 
 const TextInput = React.memo((props: { label: string } & Field<string>) => {

--- a/example/examples/UncontrolledInput.tsx
+++ b/example/examples/UncontrolledInput.tsx
@@ -1,21 +1,23 @@
 import * as React from "react";
 import { DEBUG_FormWrapper } from "../DEBUG_FormWrapper";
-import { Field, useFormio } from "../../dist";
+import { Field, getUseFormio } from "../../dist";
 
 const getRandomRGBLightColor = () =>
   "rgb(" + [Math.random(), Math.random(), Math.random()].map(i => i * 150 + 100).join(",") + ")";
 
-export const UncontrolledInput = () => {
-  const form = useFormio(
-    {
-      text: ""
-    },
-    {
-      text: {
-        validator: v => (v.length < 50 ? "LENGTH SHOULD BE >= 50" : undefined)
-      }
+const useForm = getUseFormio(
+  {
+    text: ""
+  },
+  {
+    text: {
+      validator: v => (v.length < 50 ? "LENGTH SHOULD BE >= 50" : undefined)
     }
-  );
+  }
+);
+
+export const UncontrolledInput = () => {
+  const form = useForm();
   const f = form.fields;
 
   return (

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -142,7 +142,9 @@ const useFormioAsciiArtIntro = `
   | \\_/ |, ''.'.| \\__.,          | |  | \\__. | | |     | | | | | |  | || \\__. | 
   '.__.'_/[\\__) )'.__.'         [___]  '.__.' [___]   [___||__||__][___]'.__.'  
                                                                                 
-
+`;
+/*
+`
   	
                                               ---                                  
                                           ----/  /--                               
@@ -167,6 +169,7 @@ const useFormioAsciiArtIntro = `
                  /  \ -/                                                           
                      \      
 `;
+*/
 
 const useFormioInstallationsAsciiArt = ``;
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -15,6 +15,7 @@ import { DynamicForms } from "./examples/DynamicForms";
 import { GithubIcon, UseFormioLogoHorizontalIcon } from "./icons";
 import { Header } from "./Header";
 import { InputConstrains } from "./examples/InputConstrains";
+import { OnTouchValidation } from "./examples/OnTouchValidation";
 import { OptimizedObjectRecreating } from "./examples/OptimizedObjectRecreating";
 import { RevertToInitState } from "./examples/RevertToInitState";
 import { StableMethodPointers } from "./examples/StableMethodPointers";
@@ -33,6 +34,7 @@ import { raw_DebouncedInput } from "./__generated_examples__/DebouncedInput";
 import { raw_InputConstrains } from "./__generated_examples__/InputConstrains";
 // eslint-disable-next-line max-len
 import { raw_DynamicForms } from "./__generated_examples__/DynamicForms";
+import { raw_OnTouchValidation } from "./__generated_examples__/OnTouchValidation";
 import { raw_OptimizedObjectRecreating } from "./__generated_examples__/OptimizedObjectRecreating";
 import { raw_RevertToInitState } from "./__generated_examples__/RevertToInitState";
 import { raw_StableMethodPointers } from "./__generated_examples__/StableMethodPointers";
@@ -88,6 +90,12 @@ const examples = {
       githubFileName: "SyncSetValuesBasedOnPrevValue",
       Comp: SyncSetValuesBasedOnPrevValue,
       code: raw_SyncSetValuesBasedOnPrevValue
+    },
+    {
+      title: "On touch validation",
+      githubFileName: "OnTouchValidation",
+      Comp: OnTouchValidation,
+      code: raw_OnTouchValidation
     },
     {
       title: "Uncontrolled input",

--- a/src/useFormio.ts
+++ b/src/useFormio.ts
@@ -158,7 +158,12 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
     };
   };
 
-  // use callback cannot be there coz it changed when validate pointer of fields is changed
+  // 1. add useCallback
+  // example: useCallback: `Object.stableValues(stateSchema!).map(i => i?.validator)`
+  // 2. double react render optimization
+  // check if all validators are sync/async (check if they are returning Promise)
+  // if field validator is not returning promise then do sync validation and do not change
+  // isValidating to make React.memo works correctly
   const validate = async () => {
     setFormState(p => ({
       ...p,

--- a/src/useFormio.ts
+++ b/src/useFormio.ts
@@ -30,7 +30,6 @@ export const useAsyncState = <T>(defaultState: T) => {
 const convertInitStateToFormState = <T extends Record<string, any>>(initState: T) => ({
   values: initState,
   errors: mapObjectValues(() => [] as string[], initState),
-  wasValidated: mapObjectValues(() => false, initState),
   isValidating: mapObjectValues(() => false, initState)
 });
 
@@ -131,8 +130,7 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
         setFormState(p => ({
           ...p,
           isValidating: { ...p.isValidating, [key]: false },
-          errors: { ...p.errors, [key]: newErrors },
-          wasValidated: { ...p.wasValidated, [key]: true }
+          errors: { ...p.errors, [key]: newErrors }
         }));
         const isFieldValid = newErrors.length === 0;
         return [isFieldValid, newErrors] as [boolean, typeof newErrors];

--- a/src/useFormio.ts
+++ b/src/useFormio.ts
@@ -42,7 +42,6 @@ export type Field<T> = {
   value: T;
   errors: string[];
   isValidating: boolean;
-  wasValidated: boolean;
   set: (userValue: T | ((prevState: T) => T)) => void;
   validate: () => Promise<[boolean, string[]]>;
   setErrors: (newErrors: string[] | ((prevState: string[]) => string[])) => void;
@@ -94,7 +93,6 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
       value,
       errors: formState.errors[key],
       isValidating: formState.isValidating[key],
-      wasValidated: formState.wasValidated[key],
       set: useCallback(
         (userValue: any | ((prevState: any) => any)) => {
           setFormState(prevFormState => {
@@ -184,8 +182,7 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
     setFormState(p => ({
       ...p,
       errors: newErrors,
-      isValidating: mapObjectValues(() => false, p.isValidating),
-      wasValidated: mapObjectValues(() => true, initState)
+      isValidating: mapObjectValues(() => false, p.isValidating)
     }));
 
     const isFormValid = Object.values(newErrors).flat().length === 0;

--- a/src/useFormio.ts
+++ b/src/useFormio.ts
@@ -30,6 +30,7 @@ export const useAsyncState = <T>(defaultState: T) => {
 const convertInitStateToFormState = <T extends Record<string, any>>(initState: T) => ({
   values: initState,
   errors: mapObjectValues(() => [] as string[], initState),
+  wasValidated: mapObjectValues(() => false, initState),
   isValidating: mapObjectValues(() => false, initState)
 });
 
@@ -41,6 +42,7 @@ export type Field<T> = {
   value: T;
   errors: string[];
   isValidating: boolean;
+  wasValidated: boolean;
   set: (userValue: T | ((prevState: T) => T)) => void;
   validate: () => Promise<[boolean, string[]]>;
   setErrors: (newErrors: string[] | ((prevState: string[]) => string[])) => void;
@@ -92,6 +94,7 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
       value,
       errors: formState.errors[key],
       isValidating: formState.isValidating[key],
+      wasValidated: formState.wasValidated[key],
       set: useCallback(
         (userValue: any | ((prevState: any) => any)) => {
           setFormState(prevFormState => {
@@ -130,7 +133,8 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
         setFormState(p => ({
           ...p,
           isValidating: { ...p.isValidating, [key]: false },
-          errors: { ...p.errors, [key]: newErrors }
+          errors: { ...p.errors, [key]: newErrors },
+          wasValidated: { ...p.wasValidated, [key]: true }
         }));
         const isFieldValid = newErrors.length === 0;
         return [isFieldValid, newErrors] as [boolean, typeof newErrors];
@@ -175,7 +179,8 @@ export const useFormio = <T extends Record<string, UserFieldValue>>(
     setFormState(p => ({
       ...p,
       errors: newErrors,
-      isValidating: mapObjectValues(() => false, p.isValidating)
+      isValidating: mapObjectValues(() => false, p.isValidating),
+      wasValidated: mapObjectValues(() => true, initState)
     }));
 
     const isFormValid = Object.values(newErrors).flat().length === 0;

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,5 @@
 - type inferring example
 - splash screen (with logo, inferring + light example + description)
 - screenshot/gif with type inferring
-- add tests for:
-  -
-  -
+- ## add tests for:
+  - validate on onTouch (after first inital validation has come)

--- a/todo.md
+++ b/todo.md
@@ -7,4 +7,9 @@
 - splash screen (with logo, inferring + light example + description)
 - screenshot/gif with type inferring
 - ## add tests for:
+
   - validate on onTouch (after first inital validation has come)
+
+- useWasFieldValidated
+  - should I move this hook into the core use-formio library?
+  - add tests


### PR DESCRIPTION
should `useFormio` to store `wasValidated` state or it should run validation by calling `set` by default?
Should the API be more high level or low level?
should wasValidated be public or private?

another option is to do it by your own like in the example:
```typescript
  React.useEffect(() => setWasValidated(true), [props.isValidating]);
  ```